### PR TITLE
Add Uberon IRIs and Vitessce URLs

### DIFF
--- a/data/azimuth_references.yaml
+++ b/data/azimuth_references.yaml
@@ -72,6 +72,8 @@
         file: mousebrain_crossspecies.csv
 
 - title: Human - Pancreas
+  uberon_iri: http://purl.obolibrary.org/obo/UBERON_0001264
+  vitessce_conf_url: https://raw.githubusercontent.com/satijalab/azimuth_website/master/assets/json/human_pancreas.json
   applink: https://app.azimuth.hubmapconsortium.org/app/human-pancreas
   image: pancreasumap.png
   snakemake: https://github.com/satijalab/azimuth-references/tree/master/human_pancreas
@@ -112,6 +114,8 @@
         file: humanfetus_l1.csv
 
 - title: Human - Lung
+  uberon_iri: http://purl.obolibrary.org/obo/UBERON_0002048
+  vitessce_conf_url: https://raw.githubusercontent.com/satijalab/azimuth_website/master/assets/json/human_lung.json
   applink: https://app.azimuth.hubmapconsortium.org/app/human-lung
   image: lungumap.png
   snakemake: https://github.com/satijalab/azimuth-references/tree/master/human_lung
@@ -141,6 +145,8 @@
     cellxgene: "https://cellxgene.cziscience.com/e/f72958f5-7f42-4ebb-98da-445b0c6de516.cxg/"
 
 - title: Human - Kidney
+  uberon_iri: http://purl.obolibrary.org/obo/UBERON_0002113
+  vitessce_conf_url: https://raw.githubusercontent.com/satijalab/azimuth_website/master/assets/json/human_kidney.json
   applink: https://app.azimuth.hubmapconsortium.org/app/human-kidney
   image: kidneyumap.png
   snakemake: https://github.com/satijalab/azimuth-references/tree/master/human_kidney


### PR DESCRIPTION
This information is necessary to support the portal organ pages.
- If you'd prefer different field names, I have no strong preferences.
- If you'd prefer that the Vitessce URLs be determined some other way, let me know the logic, and I can probably adjust.
- If other references besides human lung, pancreas, and kidney should be included, there are two aspects to be considered:
  - There should be a consensus with Nils (Harvard) and Katy (IU) about the organs to list.
  - Technically, besides adding Uberon and Vitessce here, you will also need to make a PR against [descriptions.yaml in portal-ui](https://github.com/hubmapconsortium/portal-ui/blob/main/organ-utils/descriptions.yaml). 